### PR TITLE
Add docker-compose and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,23 @@ npm install
 npm start
 ```
 
+#### Option 3: Docker Compose
+Spin up the File Uploader service and, optionally, the dashboard with one command.
+
+```bash
+# Build the containers (first time only)
+docker compose build file-uploader dashboard
+
+# Start only the File Uploader service
+docker compose up file-uploader
+
+# Or start both services together
+docker compose up file-uploader dashboard
+```
+
+The File Uploader will be available at [http://localhost:4000](http://localhost:4000).
+If you also run the dashboard, open [http://localhost:3000](http://localhost:3000) to upload a file. After the progress bar reaches 100%, a preview of the uploaded file appears below the bar.
+
 ### Development Workflow
 1. Choose a service to work on
 2. Read the service-specific README

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  file-uploader:
+    image: file-uploader:latest
+    build: ./file-uploader
+    ports:
+      - "4000:4000"
+
+  dashboard:
+    image: dashboard:latest
+    build: ./dashboard
+    ports:
+      - "3000:3000"
+    depends_on:
+      - file-uploader
+

--- a/file-uploader/README.md
+++ b/file-uploader/README.md
@@ -49,4 +49,21 @@ A secure and scalable file upload service with support for multiple storage back
 - Implements clean architecture with storage abstraction
 - Uses worker queues for CPU-intensive operations
 - Supports file deduplication to save storage
-- Includes comprehensive audit logging 
+- Includes comprehensive audit logging
+
+## Running with Docker Compose
+
+From the repository root you can build and start the service using Docker Compose:
+
+```bash
+# build the container
+docker compose build file-uploader
+
+# start just the file uploader
+docker compose up file-uploader
+
+# or start it together with the dashboard
+docker compose up file-uploader dashboard
+```
+
+The API listens on [http://localhost:4000](http://localhost:4000). When using the dashboard at [http://localhost:3000](http://localhost:3000), wait for the upload progress bar to hit 100% and the file preview will appear below the progress bar.


### PR DESCRIPTION
## Summary
- add docker-compose for file uploader and dashboard
- explain docker compose usage in `README.md`
- document running and previewing uploads in `file-uploader/README.md`

## Testing
- `npm run lint` *(fails: `next` not found before install)*
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684410eee140832cad9e88e7e64be185