### PR TITLE
Add recurring income planner microservice and ROI scoring utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microservices Learning Project
 
-A comprehensive collection of 24 microservices designed to showcase various aspects of modern software development, system design, and distributed computing. Each service demonstrates specific technical skills and architectural patterns commonly used in enterprise applications.
+A comprehensive collection of 25 microservices designed to showcase various aspects of modern software development, system design, and distributed computing. Each service demonstrates specific technical skills and architectural patterns commonly used in enterprise applications.
 
 ## 🚀 Project Overview
 
@@ -47,6 +47,7 @@ This project serves as a hands-on learning platform for understanding microservi
 
 ### AI & Analytics
 - **[YouTube Content Analyzer](./youtube-content-analyzer/)** - API integration and content analysis
+- **[Recurring Income Planner](./recurring-income-planner/)** - Assumptions-based scoring for micro-SaaS opportunity selection
 
 ## 🛠 Technology Stack
 

--- a/recurring-income-planner/README.md
+++ b/recurring-income-planner/README.md
@@ -1,0 +1,70 @@
+# Recurring Income Planner Service
+
+A practical, assumptions-based helper to choose which microservice idea to build first when your goal is to reach **~€400/month profit** from a small starting budget.
+
+> ⚠️ Important: no tool can guarantee fixed monthly returns. This service helps you make better decisions, reduce risk, and pick the fastest path to a realistic target.
+
+## Why this exists
+
+If you have around **€100** to invest, the best strategy is usually to build a **small B2B micro-SaaS** that:
+- solves one painful workflow,
+- charges monthly,
+- is cheap to host,
+- can be sold repeatedly.
+
+This service ranks ideas based on estimated:
+- monthly profit,
+- payback period,
+- confidence/risk,
+- required maintenance time.
+
+## Recommended first project
+
+Based on the sample assumptions in `opportunities.sample.json`, the suggested first build is:
+
+### **Invoice Follow-up and Payment Nudges**
+
+A microservice that helps freelancers and small agencies automatically:
+- detect overdue invoices,
+- send polite reminder sequences (email + optional WhatsApp/SMS),
+- escalate reminders to managers,
+- log communication history for accounting.
+
+Why this is a strong pick for your €400/month goal:
+- Clear ROI for clients (faster payments).
+- Easy to explain and sell locally.
+- Low infrastructure cost.
+- Sticky recurring usage.
+
+## Minimal monetization model
+
+- **Starter plan**: €29/month (up to 30 reminders)
+- **Pro plan**: €45/month (automation + templates)
+- **Agency plan**: €79/month (multi-client workspace)
+
+Example path to €400/month:
+- 10 clients on Pro (€45) = €450 revenue
+- ~€25 infra/tools = ~€425 estimated monthly profit
+
+## Run the scorer
+
+```bash
+cd recurring-income-planner
+python3 opportunity_scorer.py --input opportunities.sample.json --target-profit 400
+```
+
+## Implementation roadmap
+
+1. **Week 1**: Build webhook/API intake for invoices and reminders queue.
+2. **Week 2**: Add email templates, retry logic, and audit logs.
+3. **Week 3**: Stripe subscriptions + simple admin dashboard.
+4. **Week 4**: Onboard first 3 pilot users and collect testimonials.
+
+## Validation checklist (before coding more)
+
+- Talk to 15 target users (freelancers/agencies/SMBs).
+- Confirm at least 5 currently chase overdue invoices manually.
+- Pre-sell 3 pilots at discounted monthly pricing.
+- Only then scale features.
+
+The fastest path to consistent profit is not feature count — it's solving one expensive problem repeatedly.

--- a/recurring-income-planner/opportunities.sample.json
+++ b/recurring-income-planner/opportunities.sample.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "Local Lead-Capture Widget + CRM Alerts",
+    "setup_cost_eur": 100,
+    "monthly_operating_cost_eur": 20,
+    "estimated_price_eur": 39,
+    "estimated_customers": 15,
+    "estimated_hours_per_month": 8,
+    "reliability_score": 7.5,
+    "legal_complexity_score": 3,
+    "competition_score": 6
+  },
+  {
+    "name": "Appointment Reminder Automation for Clinics",
+    "setup_cost_eur": 100,
+    "monthly_operating_cost_eur": 35,
+    "estimated_price_eur": 49,
+    "estimated_customers": 10,
+    "estimated_hours_per_month": 10,
+    "reliability_score": 8.2,
+    "legal_complexity_score": 5,
+    "competition_score": 7
+  },
+  {
+    "name": "Niche SEO Rank Tracking Dashboard",
+    "setup_cost_eur": 100,
+    "monthly_operating_cost_eur": 45,
+    "estimated_price_eur": 29,
+    "estimated_customers": 20,
+    "estimated_hours_per_month": 12,
+    "reliability_score": 6.8,
+    "legal_complexity_score": 2,
+    "competition_score": 8
+  },
+  {
+    "name": "Invoice Follow-up and Payment Nudges",
+    "setup_cost_eur": 100,
+    "monthly_operating_cost_eur": 25,
+    "estimated_price_eur": 45,
+    "estimated_customers": 12,
+    "estimated_hours_per_month": 6,
+    "reliability_score": 8.7,
+    "legal_complexity_score": 4,
+    "competition_score": 5
+  }
+]

--- a/recurring-income-planner/opportunity_scorer.py
+++ b/recurring-income-planner/opportunity_scorer.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Score and rank legal micro-SaaS opportunities by risk-adjusted ROI assumptions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+
+@dataclass
+class Opportunity:
+    name: str
+    setup_cost_eur: float
+    monthly_operating_cost_eur: float
+    estimated_price_eur: float
+    estimated_customers: int
+    estimated_hours_per_month: float
+    reliability_score: float
+    legal_complexity_score: float
+    competition_score: float
+
+    @property
+    def estimated_revenue(self) -> float:
+        return self.estimated_price_eur * self.estimated_customers
+
+    @property
+    def estimated_profit(self) -> float:
+        return self.estimated_revenue - self.monthly_operating_cost_eur
+
+    @property
+    def payback_months(self) -> float:
+        profit = self.estimated_profit
+        return self.setup_cost_eur / profit if profit > 0 else float("inf")
+
+    @property
+    def risk_adjusted_score(self) -> float:
+        if self.estimated_profit <= 0:
+            return -999.0
+
+        # Higher reliability and lower complexity/competition improve confidence.
+        confidence = (
+            (self.reliability_score * 0.5)
+            + ((10 - self.legal_complexity_score) * 0.3)
+            + ((10 - self.competition_score) * 0.2)
+        ) / 10
+
+        automation_bonus = max(0.1, 1 - (self.estimated_hours_per_month / 40))
+        payback_penalty = min(2.0, self.payback_months / 12)
+
+        return (self.estimated_profit * confidence * automation_bonus) - (payback_penalty * 100)
+
+
+def load_opportunities(path: Path) -> List[Opportunity]:
+    data = json.loads(path.read_text())
+    return [Opportunity(**item) for item in data]
+
+
+def recommend(opportunities: List[Opportunity], target_profit: float) -> List[Opportunity]:
+    candidates = [o for o in opportunities if o.estimated_profit >= target_profit]
+    if not candidates:
+        candidates = opportunities
+    return sorted(candidates, key=lambda o: o.risk_adjusted_score, reverse=True)
+
+
+def format_row(rank: int, opp: Opportunity) -> str:
+    payback = "never" if opp.payback_months == float("inf") else f"{opp.payback_months:.1f} mo"
+    return (
+        f"{rank:>2}. {opp.name:<38} "
+        f"profit €{opp.estimated_profit:>7.2f} | "
+        f"payback {payback:<8} | "
+        f"score {opp.risk_adjusted_score:>7.2f}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Rank microservice business ideas by assumptions.")
+    parser.add_argument("--input", type=Path, default=Path("opportunities.sample.json"))
+    parser.add_argument("--target-profit", type=float, default=400.0)
+    args = parser.parse_args()
+
+    opportunities = load_opportunities(args.input)
+    ranking = recommend(opportunities, args.target_profit)
+
+    print("Top opportunities (assumption-based, not guaranteed):")
+    for idx, opp in enumerate(ranking, start=1):
+        print(format_row(idx, opp))
+
+    best = ranking[0]
+    print("\nRecommended first project:")
+    print(f"- {best.name}")
+    print(f"- Estimated monthly revenue: €{best.estimated_revenue:.2f}")
+    print(f"- Estimated monthly profit: €{best.estimated_profit:.2f}")
+    print(f"- Estimated payback period: {best.payback_months:.1f} months")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a pragmatic tool to identify a legal, repeatable micro-SaaS project that can reach ~€400/month starting from a €100 budget by scoring ideas on profit, payback, maintenance effort and risk.

### Description
- Add a new `recurring-income-planner/` service with a README that recommends a concrete first project (Invoice Follow-up and Payment Nudges) and an implementation roadmap.
- Implement `opportunity_scorer.py`, a CLI utility that loads opportunity assumptions, computes estimated revenue/profit/payback and a risk-adjusted score, and ranks candidates.
- Add `opportunities.sample.json` containing seed assumptions for multiple micro-SaaS ideas used by the scorer.
- Update the root `README.md` service catalog and bump the microservice count to include the new planner.

### Testing
- Ran the scorer locally with `python3 opportunity_scorer.py --input opportunities.sample.json --target-profit 400`, which completed successfully and printed ranked recommendations.
- The run produced a top recommendation of "Invoice Follow-up and Payment Nudges" with estimated monthly revenue €540.00, estimated monthly profit €515.00, and estimated payback ~0.2 months.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6953d7d54832c80d092b50e1f61d5)