### PR TITLE
Add trading-system microproject with ingestion, backtest, and paper execution

### DIFF
--- a/trading-system/.gitignore
+++ b/trading-system/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+trading_system.db

--- a/trading-system/README.md
+++ b/trading-system/README.md
@@ -1,0 +1,49 @@
+# Trading System
+
+A modular Python trading research and execution system for disciplined experimentation.
+
+## Safety principles
+- Paper trading by default.
+- Explicit risk controls before order routing.
+- No guarantee of profitability or returns.
+
+## Architecture
+
+```text
+Market Data Providers
+    ↓
+Data Fetchers / Normalizers / Validators
+    ↓
+Local Storage (SQLite or DuckDB)
+    ↓
+Feature Engineering
+    ↓
+Strategies / Model Training / Backtests
+    ↓
+Signals
+    ↓
+Risk Engine
+    ↓
+Broker Adapter (Paper by default)
+    ↓
+Orders / Fills / Positions / Equity Tracking
+    ↓
+Reports / Logs / Alerts
+```
+
+## Quick start
+```bash
+cd trading-system
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+python -m trading_system.main
+pytest -q
+```
+
+## Project layout
+- `src/trading_system/data`: ingestion, validation, normalization, storage, features.
+- `src/trading_system/research`: strategy and backtesting engine.
+- `src/trading_system/execution`: risk engine, broker adapter, portfolio tracking.
+- `src/trading_system/main.py`: example end-to-end pipeline.
+- `tests/`: unit tests for all core components.

--- a/trading-system/pyproject.toml
+++ b/trading-system/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "trading-system"
+version = "0.1.0"
+description = "Modular trading research and paper-execution framework"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+addopts = "-q"

--- a/trading-system/src/trading_system/__init__.py
+++ b/trading-system/src/trading_system/__init__.py
@@ -1,0 +1,1 @@
+"""Trading system package."""

--- a/trading-system/src/trading_system/common/__init__.py
+++ b/trading-system/src/trading_system/common/__init__.py
@@ -1,0 +1,1 @@
+"""Subpackage."""

--- a/trading-system/src/trading_system/common/models.py
+++ b/trading-system/src/trading_system/common/models.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class Side(str, Enum):
+    BUY = "buy"
+    SELL = "sell"
+
+
+@dataclass(frozen=True)
+class Candle:
+    symbol: str
+    timestamp: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+@dataclass(frozen=True)
+class Signal:
+    symbol: str
+    timestamp: datetime
+    side: Side
+    quantity: int
+    reason: str
+
+
+@dataclass(frozen=True)
+class Order:
+    id: str
+    symbol: str
+    timestamp: datetime
+    side: Side
+    quantity: int
+    limit_price: float | None = None
+
+
+@dataclass(frozen=True)
+class Fill:
+    order_id: str
+    symbol: str
+    timestamp: datetime
+    side: Side
+    quantity: int
+    price: float
+
+
+@dataclass
+class Position:
+    symbol: str
+    quantity: int = 0
+    avg_price: float = 0.0

--- a/trading-system/src/trading_system/data/__init__.py
+++ b/trading-system/src/trading_system/data/__init__.py
@@ -1,0 +1,1 @@
+"""Subpackage."""

--- a/trading-system/src/trading_system/data/pipeline.py
+++ b/trading-system/src/trading_system/data/pipeline.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from trading_system.common.models import Candle
+
+
+class InMemoryProvider:
+    """Simple provider for deterministic research and tests."""
+
+    def __init__(self, candles: Iterable[Candle]):
+        self._candles = list(candles)
+
+    def fetch(self, symbol: str) -> list[Candle]:
+        return [c for c in self._candles if c.symbol == symbol]
+
+
+class DataValidator:
+    def validate(self, candles: Iterable[Candle]) -> list[Candle]:
+        clean: list[Candle] = []
+        for candle in candles:
+            if not (candle.low <= candle.open <= candle.high):
+                continue
+            if not (candle.low <= candle.close <= candle.high):
+                continue
+            if candle.volume < 0:
+                continue
+            clean.append(candle)
+        return clean
+
+
+class DataNormalizer:
+    def normalize(self, candles: Iterable[Candle]) -> list[Candle]:
+        return sorted(candles, key=lambda c: c.timestamp)
+
+
+class SQLiteCandleStore:
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS candles (
+                    symbol TEXT NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    open REAL NOT NULL,
+                    high REAL NOT NULL,
+                    low REAL NOT NULL,
+                    close REAL NOT NULL,
+                    volume REAL NOT NULL,
+                    PRIMARY KEY(symbol, timestamp)
+                )
+                """
+            )
+
+    def write(self, candles: Iterable[Candle]) -> None:
+        rows = [asdict(c) for c in candles]
+        with self._connect() as conn:
+            conn.executemany(
+                """
+                INSERT OR REPLACE INTO candles(symbol, timestamp, open, high, low, close, volume)
+                VALUES(:symbol, :timestamp, :open, :high, :low, :close, :volume)
+                """,
+                [{**r, "timestamp": r["timestamp"].isoformat()} for r in rows],
+            )
+
+    def load(self, symbol: str) -> list[Candle]:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT symbol, timestamp, open, high, low, close, volume
+                FROM candles WHERE symbol = ? ORDER BY timestamp
+                """,
+                (symbol,),
+            )
+            rows = cursor.fetchall()
+        return [
+            Candle(
+                symbol=row[0],
+                timestamp=datetime.fromisoformat(row[1]),
+                open=row[2],
+                high=row[3],
+                low=row[4],
+                close=row[5],
+                volume=row[6],
+            )
+            for row in rows
+        ]
+
+
+class FeatureEngineer:
+    def add_sma(self, candles: list[Candle], window: int = 3) -> list[dict]:
+        output: list[dict] = []
+        closes = [c.close for c in candles]
+        for idx, candle in enumerate(candles):
+            start = max(0, idx - window + 1)
+            sub = closes[start : idx + 1]
+            sma = sum(sub) / len(sub)
+            output.append({"candle": candle, "sma": sma})
+        return output

--- a/trading-system/src/trading_system/execution/__init__.py
+++ b/trading-system/src/trading_system/execution/__init__.py
@@ -1,0 +1,1 @@
+"""Subpackage."""

--- a/trading-system/src/trading_system/execution/engine.py
+++ b/trading-system/src/trading_system/execution/engine.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from trading_system.common.models import Fill, Order, Position, Side, Signal
+
+
+@dataclass
+class RiskLimits:
+    max_order_qty: int = 100
+    max_position_qty: int = 500
+
+
+class RiskEngine:
+    def __init__(self, limits: RiskLimits):
+        self.limits = limits
+
+    def approve(self, signal: Signal, current_position: Position) -> bool:
+        if signal.quantity <= 0 or signal.quantity > self.limits.max_order_qty:
+            return False
+        projected = current_position.quantity + signal.quantity if signal.side == Side.BUY else current_position.quantity - signal.quantity
+        return abs(projected) <= self.limits.max_position_qty
+
+
+class PaperBroker:
+    """Always paper mode; executes at provided market price."""
+
+    def submit(self, signal: Signal, market_price: float) -> tuple[Order, Fill]:
+        order = Order(
+            id=str(uuid4()),
+            symbol=signal.symbol,
+            timestamp=signal.timestamp,
+            side=signal.side,
+            quantity=signal.quantity,
+        )
+        fill = Fill(
+            order_id=order.id,
+            symbol=order.symbol,
+            timestamp=datetime.now(UTC),
+            side=order.side,
+            quantity=order.quantity,
+            price=market_price,
+        )
+        return order, fill
+
+
+class PortfolioTracker:
+    def __init__(self, starting_cash: float = 50_000):
+        self.cash = starting_cash
+        self.positions: dict[str, Position] = {}
+        self.order_log: list[Order] = []
+        self.fill_log: list[Fill] = []
+
+    def _position(self, symbol: str) -> Position:
+        if symbol not in self.positions:
+            self.positions[symbol] = Position(symbol=symbol)
+        return self.positions[symbol]
+
+    def apply_fill(self, fill: Fill) -> None:
+        pos = self._position(fill.symbol)
+        if fill.side == Side.BUY:
+            total_cost = pos.avg_price * pos.quantity + fill.price * fill.quantity
+            pos.quantity += fill.quantity
+            pos.avg_price = total_cost / pos.quantity
+            self.cash -= fill.price * fill.quantity
+        else:
+            pos.quantity -= fill.quantity
+            self.cash += fill.price * fill.quantity
+            if pos.quantity == 0:
+                pos.avg_price = 0.0
+        self.fill_log.append(fill)
+
+    def equity(self, last_prices: dict[str, float]) -> float:
+        holdings = sum(p.quantity * last_prices.get(sym, p.avg_price) for sym, p in self.positions.items())
+        return self.cash + holdings
+
+
+class ExecutionService:
+    def __init__(self, risk_engine: RiskEngine, broker: PaperBroker, portfolio: PortfolioTracker):
+        self.risk_engine = risk_engine
+        self.broker = broker
+        self.portfolio = portfolio
+
+    def process_signal(self, signal: Signal, market_price: float) -> bool:
+        position = self.portfolio.positions.get(signal.symbol, Position(signal.symbol))
+        if not self.risk_engine.approve(signal, position):
+            return False
+
+        order, fill = self.broker.submit(signal, market_price)
+        self.portfolio.order_log.append(order)
+        self.portfolio.apply_fill(fill)
+        return True

--- a/trading-system/src/trading_system/main.py
+++ b/trading-system/src/trading_system/main.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from trading_system.common.models import Candle
+from trading_system.data.pipeline import DataNormalizer, DataValidator, FeatureEngineer, InMemoryProvider, SQLiteCandleStore
+from trading_system.execution.engine import ExecutionService, PaperBroker, PortfolioTracker, RiskEngine, RiskLimits
+from trading_system.research.backtest import Backtester, MovingAverageCrossStrategy
+
+
+def sample_candles(symbol: str = "AAPL") -> list[Candle]:
+    start = datetime(2024, 1, 1)
+    closes = [100, 101, 103, 102, 104, 107, 105, 106]
+    return [
+        Candle(
+            symbol=symbol,
+            timestamp=start + timedelta(days=i),
+            open=close - 0.5,
+            high=close + 1,
+            low=close - 1,
+            close=close,
+            volume=10_000 + i * 100,
+        )
+        for i, close in enumerate(closes)
+    ]
+
+
+def run_pipeline() -> dict:
+    provider = InMemoryProvider(sample_candles())
+    candles = provider.fetch("AAPL")
+    candles = DataNormalizer().normalize(DataValidator().validate(candles))
+
+    store = SQLiteCandleStore(Path("trading_system.db"))
+    store.write(candles)
+    loaded = store.load("AAPL")
+
+    features = FeatureEngineer().add_sma(loaded)
+
+    strategy = MovingAverageCrossStrategy(fast_window=2, slow_window=4, qty=10)
+    signals = strategy.generate_signals(loaded)
+    backtest = Backtester().run(loaded, signals)
+
+    execution = ExecutionService(RiskEngine(RiskLimits()), PaperBroker(), PortfolioTracker())
+    for signal in signals:
+        matching = [c for c in loaded if c.timestamp == signal.timestamp]
+        if matching:
+            execution.process_signal(signal, market_price=matching[0].close)
+
+    last_price = loaded[-1].close if loaded else 0.0
+    equity = execution.portfolio.equity({"AAPL": last_price})
+
+    return {
+        "candles": len(loaded),
+        "features": len(features),
+        "signals": len(signals),
+        "backtest_return": backtest.total_return,
+        "executed_orders": len(execution.portfolio.order_log),
+        "equity": equity,
+    }
+
+
+if __name__ == "__main__":
+    result = run_pipeline()
+    print("Trading system run complete:")
+    for k, v in result.items():
+        print(f"- {k}: {v}")

--- a/trading-system/src/trading_system/research/__init__.py
+++ b/trading-system/src/trading_system/research/__init__.py
@@ -1,0 +1,1 @@
+"""Subpackage."""

--- a/trading-system/src/trading_system/research/backtest.py
+++ b/trading-system/src/trading_system/research/backtest.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from trading_system.common.models import Candle, Side, Signal
+
+
+class MovingAverageCrossStrategy:
+    """Generates buy/sell signals using fast and slow SMA crossover."""
+
+    def __init__(self, fast_window: int = 3, slow_window: int = 5, qty: int = 1):
+        if fast_window >= slow_window:
+            raise ValueError("fast_window must be less than slow_window")
+        self.fast_window = fast_window
+        self.slow_window = slow_window
+        self.qty = qty
+
+    def _sma(self, candles: list[Candle], idx: int, window: int) -> float:
+        start = max(0, idx - window + 1)
+        subset = candles[start : idx + 1]
+        return sum(c.close for c in subset) / len(subset)
+
+    def generate_signals(self, candles: list[Candle]) -> list[Signal]:
+        signals: list[Signal] = []
+        if not candles:
+            return signals
+
+        last_state: str | None = None
+        for idx in range(len(candles)):
+            fast = self._sma(candles, idx, self.fast_window)
+            slow = self._sma(candles, idx, self.slow_window)
+            state = "above" if fast > slow else "below"
+            if last_state and state != last_state:
+                side = Side.BUY if state == "above" else Side.SELL
+                signals.append(
+                    Signal(
+                        symbol=candles[idx].symbol,
+                        timestamp=candles[idx].timestamp,
+                        side=side,
+                        quantity=self.qty,
+                        reason=f"ma_cross:{last_state}->{state}",
+                    )
+                )
+            last_state = state
+        return signals
+
+
+@dataclass
+class BacktestResult:
+    total_return: float
+    trades: int
+    win_rate: float
+    equity_curve: list[float]
+
+
+class Backtester:
+    def run(self, candles: list[Candle], signals: list[Signal], initial_cash: float = 10_000) -> BacktestResult:
+        if not candles:
+            return BacktestResult(0.0, 0, 0.0, [initial_cash])
+
+        by_ts = {s.timestamp: s for s in signals}
+        cash = initial_cash
+        position = 0
+        entry_price = 0.0
+        wins = 0
+        closed = 0
+        equity_curve: list[float] = []
+
+        for candle in candles:
+            signal = by_ts.get(candle.timestamp)
+            if signal:
+                if signal.side == Side.BUY:
+                    cost = signal.quantity * candle.close
+                    if cash >= cost:
+                        cash -= cost
+                        position += signal.quantity
+                        entry_price = candle.close
+                else:
+                    qty = min(position, signal.quantity)
+                    if qty > 0:
+                        cash += qty * candle.close
+                        if candle.close > entry_price:
+                            wins += 1
+                        position -= qty
+                        closed += 1
+            equity_curve.append(cash + position * candle.close)
+
+        total_return = (equity_curve[-1] - initial_cash) / initial_cash
+        win_rate = (wins / closed) if closed else 0.0
+        return BacktestResult(total_return, closed, win_rate, equity_curve)

--- a/trading-system/tests/test_data_pipeline.py
+++ b/trading-system/tests/test_data_pipeline.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from trading_system.common.models import Candle
+from trading_system.data.pipeline import DataNormalizer, DataValidator, FeatureEngineer, SQLiteCandleStore
+
+
+def test_validate_normalize_and_features(tmp_path):
+    candles = [
+        Candle("AAPL", datetime(2024, 1, 2), 10, 12, 9, 11, 100),
+        Candle("AAPL", datetime(2024, 1, 1), 10, 12, 9, 11, 100),
+        Candle("AAPL", datetime(2024, 1, 3), 15, 14, 9, 11, 100),
+    ]
+    valid = DataValidator().validate(candles)
+    assert len(valid) == 2
+
+    normalized = DataNormalizer().normalize(valid)
+    assert normalized[0].timestamp < normalized[1].timestamp
+
+    feats = FeatureEngineer().add_sma(normalized, window=2)
+    assert len(feats) == 2
+    assert "sma" in feats[0]
+
+    store = SQLiteCandleStore(tmp_path / "candles.db")
+    store.write(normalized)
+    loaded = store.load("AAPL")
+    assert len(loaded) == 2

--- a/trading-system/tests/test_execution_engine.py
+++ b/trading-system/tests/test_execution_engine.py
@@ -1,0 +1,18 @@
+from datetime import UTC, datetime
+
+from trading_system.common.models import Position, Side, Signal
+from trading_system.execution.engine import ExecutionService, PaperBroker, PortfolioTracker, RiskEngine, RiskLimits
+
+
+def test_risk_engine_and_execution():
+    risk = RiskEngine(RiskLimits(max_order_qty=10, max_position_qty=20))
+    broker = PaperBroker()
+    portfolio = PortfolioTracker(starting_cash=1000)
+    service = ExecutionService(risk, broker, portfolio)
+
+    signal = Signal("AAPL", datetime.now(UTC), Side.BUY, 5, "test")
+    assert service.process_signal(signal, market_price=10)
+    assert portfolio.positions["AAPL"].quantity == 5
+
+    bad_signal = Signal("AAPL", datetime.now(UTC), Side.BUY, 50, "too_large")
+    assert not risk.approve(bad_signal, Position("AAPL", quantity=5))

--- a/trading-system/tests/test_research_backtest.py
+++ b/trading-system/tests/test_research_backtest.py
@@ -1,0 +1,24 @@
+from datetime import datetime, timedelta
+
+from trading_system.common.models import Candle
+from trading_system.research.backtest import Backtester, MovingAverageCrossStrategy
+
+
+def _candles():
+    start = datetime(2024, 1, 1)
+    closes = [10, 11, 12, 11, 10, 12]
+    return [
+        Candle("AAPL", start + timedelta(days=i), c - 1, c + 1, c - 2, c, 1000)
+        for i, c in enumerate(closes)
+    ]
+
+
+def test_strategy_and_backtester():
+    candles = _candles()
+    strategy = MovingAverageCrossStrategy(fast_window=2, slow_window=3, qty=5)
+    signals = strategy.generate_signals(candles)
+    assert signals
+
+    result = Backtester().run(candles, signals, initial_cash=1000)
+    assert isinstance(result.total_return, float)
+    assert len(result.equity_curve) == len(candles)


### PR DESCRIPTION
### Motivation
- Provide a compact, modular Python trading research and execution microproject that supports deterministic data ingestion, feature engineering, strategy research, backtesting, and risk-gated paper execution. 
- Ship a small, opinionated scaffold intended for disciplined experimentation that defaults to paper trading and enforces simple risk limits. 
- Offer a runnable example and a minimal test-suite to enable rapid validation and extension.

### Description
- Added a new `trading-system/` microproject with project metadata (`pyproject.toml`), documentation (`README.md`), and ignore rules (`.gitignore`).
- Implemented shared domain models in `src/trading_system/common/models.py` including `Candle`, `Signal`, `Order`, `Fill`, `Position`, and `Side`.
- Built the data pipeline in `src/trading_system/data/pipeline.py` with `InMemoryProvider`, `DataValidator`, `DataNormalizer`, `SQLiteCandleStore`, and a simple `FeatureEngineer.add_sma`.
- Implemented research and execution subsystems: `MovingAverageCrossStrategy` and `Backtester` under `research/`, and `RiskEngine`, `PaperBroker`, `PortfolioTracker`, and `ExecutionService` under `execution/`, plus an end-to-end example in `src/trading_system/main.py`.

### Testing
- Ran the example pipeline with `PYTHONPATH=src python -m trading_system.main` to exercise the end-to-end flow and observe run metrics. 
- Executed the automated test-suite with `pytest` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b69c638ca0832c9e2844d8f826a9af)