### PR TITLE
Add modular trading-system package with end-to-end pipeline and tests

### DIFF
--- a/trading-system/.gitignore
+++ b/trading-system/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/

--- a/trading-system/README.md
+++ b/trading-system/README.md
@@ -1,0 +1,99 @@
+# Trading System
+
+A modular Python microproject for trading research and execution with a strict **paper-trading default**.
+
+> This project is for disciplined experimentation only. It does **not** assume profitability and does **not** guarantee returns.
+
+## Overview
+
+This system is built for:
+
+1. Historical market data ingestion
+2. Strategy research and backtesting
+3. Paper-trading execution with strict risk controls
+
+## Core Components
+
+### 1) Data Ingestion
+- Deterministic/synthetic market data provider for reproducible experiments
+- OHLCV validation and normalization
+- Local persistence in SQLite
+- Feature engineering inputs emitted for research and execution
+
+### 2) Strategy Research + Backtesting
+- Rule-based strategy: moving-average crossover
+- ML-assisted overlay: nearest-centroid direction model over engineered features
+- Historical replay backtest with equity, returns, drawdown, and trade counts
+
+### 3) Execution + Monitoring
+- Risk checks before each target-position order
+- Paper broker adapter (default mode)
+- Order event log with filled/rejected statuses
+- Portfolio tracking and human-readable operational report
+
+## Architecture
+
+```text
+Market Data Providers
+    ↓
+Data Fetchers / Normalizers / Validators
+    ↓
+Local Storage (SQLite)
+    ↓
+Feature Engineering
+    ↓
+Strategies / Model Training / Backtests
+    ↓
+Signals
+    ↓
+Risk Engine
+    ↓
+Broker Adapter (Paper by default)
+    ↓
+Orders / Fills / Positions / Equity Tracking
+    ↓
+Reports / Logs / Alerts
+```
+
+## Project Layout
+
+```text
+trading-system/
+├── pyproject.toml
+├── README.md
+├── src/trading_system/
+│   ├── __init__.py
+│   ├── backtest.py
+│   ├── broker.py
+│   ├── cli.py
+│   ├── config.py
+│   ├── data_ingestion.py
+│   ├── execution.py
+│   ├── features.py
+│   ├── pipeline.py
+│   ├── reporting.py
+│   ├── risk.py
+│   ├── storage.py
+│   └── strategy.py
+└── tests/
+    └── test_pipeline.py
+```
+
+## Quickstart
+
+```bash
+cd trading-system
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+pytest -q
+trading-system
+```
+
+## Test readiness
+
+Yes — you can start testing now.
+
+- Package import path for tests is configured in `pyproject.toml`.
+- End-to-end pipeline test is included.
+- CLI runs the full ingestion → research/backtest → execution/report flow.

--- a/trading-system/pyproject.toml
+++ b/trading-system/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "trading-system"
+version = "0.2.0"
+description = "Modular trading research and paper-execution microproject"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
+[project.scripts]
+trading-system = "trading_system.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/trading-system/src/trading_system/__init__.py
+++ b/trading-system/src/trading_system/__init__.py
@@ -1,0 +1,5 @@
+"""Trading system package."""
+
+from .pipeline import run_trading_system
+
+__all__ = ["run_trading_system"]

--- a/trading-system/src/trading_system/backtest.py
+++ b/trading-system/src/trading_system/backtest.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class BacktestResult:
+    final_equity: float
+    total_return: float
+    max_drawdown: float
+    trades: int
+
+
+def run_backtest(closes: list[float], signals: list[int], starting_cash: float) -> BacktestResult:
+    cash = starting_cash
+    units = 0
+    trades = 0
+    equity_curve: list[float] = []
+
+    for close, signal in zip(closes, signals):
+        target_units = signal
+        delta = target_units - units
+        if delta != 0:
+            trades += 1
+        cash -= delta * close
+        units = target_units
+        equity_curve.append(cash + units * close)
+
+    if not equity_curve:
+        return BacktestResult(starting_cash, 0.0, 0.0, 0)
+
+    peak = equity_curve[0]
+    max_drawdown = 0.0
+    for equity in equity_curve:
+        peak = max(peak, equity)
+        drawdown = (peak - equity) / peak if peak else 0.0
+        max_drawdown = max(max_drawdown, drawdown)
+
+    final_equity = equity_curve[-1]
+    return BacktestResult(
+        final_equity=final_equity,
+        total_return=(final_equity - starting_cash) / starting_cash,
+        max_drawdown=max_drawdown,
+        trades=trades,
+    )

--- a/trading-system/src/trading_system/broker.py
+++ b/trading-system/src/trading_system/broker.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class OrderEvent:
+    ts: str
+    symbol: str
+    target_units: int
+    fill_price: float
+    status: str
+    reason: str = ""
+
+
+class PaperBrokerAdapter:
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+
+    def execute_target(self, ts: str, target_units: int, fill_price: float) -> OrderEvent:
+        return OrderEvent(
+            ts=ts,
+            symbol=self.symbol,
+            target_units=target_units,
+            fill_price=fill_price,
+            status="filled",
+        )

--- a/trading-system/src/trading_system/cli.py
+++ b/trading-system/src/trading_system/cli.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from .pipeline import run_trading_system
+
+
+def main() -> None:
+    result = run_trading_system()
+    print(result["report"])
+
+
+if __name__ == "__main__":
+    main()

--- a/trading-system/src/trading_system/config.py
+++ b/trading-system/src/trading_system/config.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RiskLimits:
+    max_position_units: int = 1
+    max_notional_per_order: float = 25_000.0
+    max_daily_loss: float = 2_000.0
+
+
+@dataclass(frozen=True)
+class SystemConfig:
+    symbol: str = "DEMO"
+    starting_cash: float = 100_000.0
+    short_window: int = 5
+    long_window: int = 20
+    history_bars: int = 250
+    use_ml_assist: bool = True
+    db_path: str = ":memory:"
+    risk_limits: RiskLimits = RiskLimits()
+    paper_trading: bool = True

--- a/trading-system/src/trading_system/data_ingestion.py
+++ b/trading-system/src/trading_system/data_ingestion.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from random import Random
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class OHLCVRecord:
+    ts: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+class SyntheticMarketDataProvider:
+    """Deterministic provider for repeatable local research and tests."""
+
+    def __init__(self, seed: int = 7) -> None:
+        self._rng = Random(seed)
+
+    def fetch_ohlcv(self, bars: int = 250, start_price: float = 100.0) -> list[OHLCVRecord]:
+        rows: list[OHLCVRecord] = []
+        ts = datetime(2024, 1, 1)
+        price = start_price
+
+        for _ in range(bars):
+            drift = self._rng.uniform(-1.2, 1.4)
+            open_px = price
+            close_px = max(1.0, open_px + drift)
+            high_px = max(open_px, close_px) + self._rng.uniform(0.0, 0.6)
+            low_px = min(open_px, close_px) - self._rng.uniform(0.0, 0.6)
+            volume = self._rng.uniform(8_000, 60_000)
+            rows.append(
+                OHLCVRecord(
+                    ts=ts,
+                    open=round(open_px, 4),
+                    high=round(high_px, 4),
+                    low=round(max(0.5, low_px), 4),
+                    close=round(close_px, 4),
+                    volume=round(volume, 2),
+                )
+            )
+            ts += timedelta(days=1)
+            price = close_px
+        return rows
+
+
+def validate_ohlcv(records: Iterable[OHLCVRecord]) -> list[OHLCVRecord]:
+    validated: list[OHLCVRecord] = []
+    for rec in records:
+        if rec.high < rec.low:
+            continue
+        if rec.volume < 0:
+            continue
+        if not (rec.low <= rec.open <= rec.high):
+            continue
+        if not (rec.low <= rec.close <= rec.high):
+            continue
+        validated.append(rec)
+    return validated
+
+
+def normalize_ohlcv(records: Iterable[OHLCVRecord]) -> list[OHLCVRecord]:
+    """Sort rows and clamp malformed values into a consistent canonical form."""
+
+    sorted_rows = sorted(records, key=lambda r: r.ts)
+    normalized: list[OHLCVRecord] = []
+
+    for rec in sorted_rows:
+        high = max(rec.open, rec.close, rec.high, rec.low)
+        low = min(rec.open, rec.close, rec.high, rec.low)
+        normalized.append(
+            OHLCVRecord(
+                ts=rec.ts,
+                open=float(rec.open),
+                high=float(high),
+                low=float(low),
+                close=float(rec.close),
+                volume=max(0.0, float(rec.volume)),
+            )
+        )
+
+    return normalized

--- a/trading-system/src/trading_system/execution.py
+++ b/trading-system/src/trading_system/execution.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .broker import OrderEvent, PaperBrokerAdapter
+from .config import RiskLimits
+from .risk import evaluate_order
+
+
+@dataclass
+class PortfolioState:
+    cash: float
+    units: int = 0
+    realized_pnl_today: float = 0.0
+    events: list[OrderEvent] = field(default_factory=list)
+    rejected_orders: int = 0
+
+
+def run_execution(
+    *,
+    timestamps: list[str],
+    closes: list[float],
+    signals: list[int],
+    symbol: str,
+    starting_cash: float,
+    limits: RiskLimits,
+) -> PortfolioState:
+    broker = PaperBrokerAdapter(symbol)
+    state = PortfolioState(cash=starting_cash)
+    prior_price = closes[0] if closes else 0.0
+
+    for ts, close, signal in zip(timestamps, closes, signals):
+        state.realized_pnl_today += state.units * (close - prior_price)
+
+        decision = evaluate_order(
+            target_units=signal,
+            current_units=state.units,
+            price=close,
+            realized_pnl_today=state.realized_pnl_today,
+            limits=limits,
+        )
+
+        if not decision.allowed:
+            state.rejected_orders += 1
+            state.events.append(
+                OrderEvent(
+                    ts=ts,
+                    symbol=symbol,
+                    target_units=state.units,
+                    fill_price=close,
+                    status="rejected",
+                    reason=decision.reason,
+                )
+            )
+            prior_price = close
+            continue
+
+        delta = signal - state.units
+        state.cash -= delta * close
+        state.units = signal
+        state.events.append(broker.execute_target(ts=ts, target_units=signal, fill_price=close))
+        prior_price = close
+
+    return state

--- a/trading-system/src/trading_system/features.py
+++ b/trading-system/src/trading_system/features.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+
+FeatureRow = dict[str, float | int | None]
+
+
+def simple_moving_average(values: list[float], window: int) -> list[float | None]:
+    if window <= 0:
+        raise ValueError("window must be positive")
+
+    out: list[float | None] = []
+    running_sum = 0.0
+    for index, value in enumerate(values):
+        running_sum += value
+        if index >= window:
+            running_sum -= values[index - window]
+        if index + 1 < window:
+            out.append(None)
+        else:
+            out.append(running_sum / window)
+    return out
+
+
+def _rolling_std(values: list[float], window: int) -> list[float | None]:
+    if window <= 1:
+        return [0.0 for _ in values]
+
+    out: list[float | None] = []
+    for i in range(len(values)):
+        if i + 1 < window:
+            out.append(None)
+            continue
+        chunk = values[i + 1 - window : i + 1]
+        mean = sum(chunk) / window
+        variance = sum((x - mean) ** 2 for x in chunk) / (window - 1)
+        out.append(variance**0.5)
+    return out
+
+
+def build_feature_frame(closes: list[float], short_window: int, long_window: int) -> list[FeatureRow]:
+    short_ma = simple_moving_average(closes, short_window)
+    long_ma = simple_moving_average(closes, long_window)
+    vol = _rolling_std(closes, short_window)
+
+    rows: list[FeatureRow] = []
+    for i, close in enumerate(closes):
+        prev_close = closes[i - 1] if i else close
+        ret = 0.0 if i == 0 else (close - prev_close) / prev_close
+        rows.append(
+            {
+                "close": close,
+                "return_1": ret,
+                "short_ma": short_ma[i],
+                "long_ma": long_ma[i],
+                "ma_spread": None if short_ma[i] is None or long_ma[i] is None else short_ma[i] - long_ma[i],
+                "volatility": vol[i],
+            }
+        )
+    return rows

--- a/trading-system/src/trading_system/pipeline.py
+++ b/trading-system/src/trading_system/pipeline.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from .backtest import BacktestResult, run_backtest
+from .config import SystemConfig
+from .data_ingestion import SyntheticMarketDataProvider, normalize_ohlcv, validate_ohlcv
+from .execution import PortfolioState, run_execution
+from .features import build_feature_frame
+from .reporting import build_report
+from .storage import SQLiteMarketStore
+from .strategy import generate_signals
+
+
+def run_trading_system(config: SystemConfig | None = None) -> dict:
+    cfg = config or SystemConfig()
+
+    provider = SyntheticMarketDataProvider()
+    raw = provider.fetch_ohlcv(bars=cfg.history_bars)
+    clean = normalize_ohlcv(validate_ohlcv(raw))
+
+    store = SQLiteMarketStore(db_path=cfg.db_path)
+    store.save_ohlcv(clean)
+    ts_and_closes = store.load_closes()
+
+    timestamps = [ts for ts, _ in ts_and_closes]
+    closes = [close for _, close in ts_and_closes]
+
+    features = build_feature_frame(closes, cfg.short_window, cfg.long_window)
+    signals = generate_signals(features, use_ml_assist=cfg.use_ml_assist)
+
+    backtest: BacktestResult = run_backtest(closes, signals, cfg.starting_cash)
+    execution: PortfolioState = run_execution(
+        timestamps=timestamps,
+        closes=closes,
+        signals=signals,
+        symbol=cfg.symbol,
+        starting_cash=cfg.starting_cash,
+        limits=cfg.risk_limits,
+    )
+    report = build_report(backtest=backtest, execution=execution, last_close=closes[-1])
+
+    return {
+        "config": cfg,
+        "rows_loaded": len(clean),
+        "features": features,
+        "signals": signals,
+        "backtest": backtest,
+        "execution": execution,
+        "report": report,
+    }

--- a/trading-system/src/trading_system/reporting.py
+++ b/trading-system/src/trading_system/reporting.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from .backtest import BacktestResult
+from .execution import PortfolioState
+
+
+def build_report(*, backtest: BacktestResult, execution: PortfolioState, last_close: float) -> str:
+    equity = execution.cash + execution.units * last_close
+    lines = [
+        "=== Trading System Report ===",
+        f"Backtest final equity: {backtest.final_equity:.2f}",
+        f"Backtest total return: {backtest.total_return:.2%}",
+        f"Backtest max drawdown: {backtest.max_drawdown:.2%}",
+        f"Backtest trades: {backtest.trades}",
+        f"Paper execution cash: {execution.cash:.2f}",
+        f"Paper execution units: {execution.units}",
+        f"Paper execution equity: {equity:.2f}",
+        f"Filled/rejected events: {sum(e.status == 'filled' for e in execution.events)}/{execution.rejected_orders}",
+    ]
+    return "\n".join(lines)

--- a/trading-system/src/trading_system/risk.py
+++ b/trading-system/src/trading_system/risk.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .config import RiskLimits
+
+
+@dataclass
+class RiskDecision:
+    allowed: bool
+    reason: str
+
+
+def evaluate_order(
+    *,
+    target_units: int,
+    current_units: int,
+    price: float,
+    realized_pnl_today: float,
+    limits: RiskLimits,
+) -> RiskDecision:
+    if abs(target_units) > limits.max_position_units:
+        return RiskDecision(False, "position limit exceeded")
+
+    delta_units = abs(target_units - current_units)
+    if (delta_units * price) > limits.max_notional_per_order:
+        return RiskDecision(False, "order notional limit exceeded")
+
+    if realized_pnl_today <= -abs(limits.max_daily_loss):
+        return RiskDecision(False, "daily loss limit hit")
+
+    return RiskDecision(True, "approved")

--- a/trading-system/src/trading_system/storage.py
+++ b/trading-system/src/trading_system/storage.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from .data_ingestion import OHLCVRecord
+
+
+class SQLiteMarketStore:
+    def __init__(self, db_path: str | Path = ":memory:") -> None:
+        self.conn = sqlite3.connect(str(db_path))
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ohlcv (
+                ts TEXT PRIMARY KEY,
+                open REAL NOT NULL,
+                high REAL NOT NULL,
+                low REAL NOT NULL,
+                close REAL NOT NULL,
+                volume REAL NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+
+    def save_ohlcv(self, records: list[OHLCVRecord]) -> None:
+        self.conn.executemany(
+            """
+            INSERT OR REPLACE INTO ohlcv(ts, open, high, low, close, volume)
+            VALUES(?, ?, ?, ?, ?, ?)
+            """,
+            [(r.ts.isoformat(), r.open, r.high, r.low, r.close, r.volume) for r in records],
+        )
+        self.conn.commit()
+
+    def load_ohlcv(self) -> list[tuple[str, float, float, float, float, float]]:
+        cur = self.conn.execute("SELECT ts, open, high, low, close, volume FROM ohlcv ORDER BY ts")
+        return [(str(r[0]), float(r[1]), float(r[2]), float(r[3]), float(r[4]), float(r[5])) for r in cur.fetchall()]
+
+    def load_closes(self) -> list[tuple[str, float]]:
+        cur = self.conn.execute("SELECT ts, close FROM ohlcv ORDER BY ts")
+        return [(str(row[0]), float(row[1])) for row in cur.fetchall()]

--- a/trading-system/src/trading_system/strategy.py
+++ b/trading-system/src/trading_system/strategy.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .features import FeatureRow
+
+
+def ma_crossover_signal(feature_row: FeatureRow) -> int:
+    short_ma = feature_row["short_ma"]
+    long_ma = feature_row["long_ma"]
+
+    if short_ma is None or long_ma is None:
+        return 0
+    if short_ma > long_ma:
+        return 1
+    if short_ma < long_ma:
+        return -1
+    return 0
+
+
+@dataclass
+class NearestCentroidDirectionModel:
+    """Minimal ML-assisted direction model using feature centroids."""
+
+    up_centroid: tuple[float, float] = (0.0, 0.0)
+    down_centroid: tuple[float, float] = (0.0, 0.0)
+
+    def fit(self, features: list[FeatureRow]) -> None:
+        up: list[tuple[float, float]] = []
+        down: list[tuple[float, float]] = []
+
+        for row in features:
+            spread = row["ma_spread"]
+            ret = row["return_1"]
+            if spread is None:
+                continue
+            point = (float(spread), float(ret))
+            if ret >= 0:
+                up.append(point)
+            else:
+                down.append(point)
+
+        self.up_centroid = _mean_point(up) if up else (0.0, 0.0)
+        self.down_centroid = _mean_point(down) if down else (0.0, 0.0)
+
+    def predict_signal(self, row: FeatureRow) -> int:
+        spread = row["ma_spread"]
+        ret = row["return_1"]
+        if spread is None:
+            return 0
+        point = (float(spread), float(ret))
+
+        up_dist = _distance(point, self.up_centroid)
+        down_dist = _distance(point, self.down_centroid)
+        if up_dist < down_dist:
+            return 1
+        if down_dist < up_dist:
+            return -1
+        return 0
+
+
+def _mean_point(points: list[tuple[float, float]]) -> tuple[float, float]:
+    x = sum(p[0] for p in points) / len(points)
+    y = sum(p[1] for p in points) / len(points)
+    return (x, y)
+
+
+def _distance(a: tuple[float, float], b: tuple[float, float]) -> float:
+    return ((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2) ** 0.5
+
+
+def generate_signals(features: list[FeatureRow], use_ml_assist: bool = True) -> list[int]:
+    base = [ma_crossover_signal(row) for row in features]
+    if not use_ml_assist:
+        return base
+
+    model = NearestCentroidDirectionModel()
+    model.fit(features)
+
+    merged: list[int] = []
+    for row, base_signal in zip(features, base):
+        ml_signal = model.predict_signal(row)
+        if base_signal == 0:
+            merged.append(ml_signal)
+        elif ml_signal == 0:
+            merged.append(base_signal)
+        else:
+            merged.append(base_signal if base_signal == ml_signal else 0)
+    return merged

--- a/trading-system/tests/test_pipeline.py
+++ b/trading-system/tests/test_pipeline.py
@@ -1,0 +1,26 @@
+from trading_system.config import RiskLimits, SystemConfig
+from trading_system.pipeline import run_trading_system
+
+
+def test_pipeline_runs_end_to_end() -> None:
+    result = run_trading_system()
+
+    assert result["rows_loaded"] > 0
+    assert len(result["features"]) == result["rows_loaded"]
+    assert len(result["signals"]) == result["rows_loaded"]
+
+    report = result["report"]
+    assert "Trading System Report" in report
+    assert "Filled/rejected events" in report
+
+
+def test_risk_limits_can_force_rejections() -> None:
+    cfg = SystemConfig(
+        risk_limits=RiskLimits(
+            max_position_units=1,
+            max_notional_per_order=1.0,
+            max_daily_loss=2_000.0,
+        )
+    )
+    result = run_trading_system(cfg)
+    assert result["execution"].rejected_orders > 0


### PR DESCRIPTION
### Motivation

- Provide a small, modular Python microproject for reproducible trading research and paper execution with sane defaults and strict paper-trading mode.
- Enable deterministic, local experimentation by including a synthetic market data provider, local SQLite persistence, simple feature engineering, and risk-aware execution. 

### Description

- Add project layout and packaging via `pyproject.toml` and top-level `README.md` documenting the system and quickstart. 
- Implement core modules under `src/trading_system/`: `data_ingestion` (deterministic `SyntheticMarketDataProvider`, `validate_ohlcv`, `normalize_ohlcv`), `features` (SMA, rolling std, `build_feature_frame`), `strategy` (MA crossover, `NearestCentroidDirectionModel`, `generate_signals`), `backtest` (`run_backtest` and `BacktestResult`), `execution` (`run_execution`, `PortfolioState`), `broker` (simple `PaperBrokerAdapter`, `OrderEvent`), `risk` (`evaluate_order`, `RiskDecision`), `storage` (`SQLiteMarketStore`), `reporting` (`build_report`), `pipeline` (`run_trading_system`) and `cli` (`main` entrypoint). 
- Wire components to run a full ingestion → features → signals → backtest → paper-execution → reporting flow and expose `trading-system` console script. 
- Add `tests/test_pipeline.py` to validate end-to-end pipeline execution and that `RiskLimits` can force order rejections. 
- Add `.gitignore` entries for common Python artifacts.

### Testing

- Ran `pytest -q` which executed `tests/test_pipeline.py` including `test_pipeline_runs_end_to_end` and `test_risk_limits_can_force_rejections` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b69c4cbdec832cae71ee00e6a5be27)